### PR TITLE
fix image rounding property of list thumbnail

### DIFF
--- a/app/assets/stylesheets/oneline.scss
+++ b/app/assets/stylesheets/oneline.scss
@@ -25,7 +25,7 @@
 }
 
 .oneline-image-box {
-  border-radius: 5%;
+  border-radius: 18px;
   margin-right: 10px;
   padding: 5px !important;
 }


### PR DESCRIPTION
### Trying to fix...

<img width="385" alt="스크린샷 2020-11-08 17 29 53" src="https://user-images.githubusercontent.com/1370225/98460470-0bdb9000-21e8-11eb-8436-0048cb81d1b0.png">
The image is rounded while the radius is uneven.

Since the `border-radius` value is in percents, the corner rounding is uneven when the element is not square.

### What's changed

The border-radius value is now based on px.
`18px` was the closest integer in ratio to current size of image(360px approx.).