### PR TITLE
oneline: click image to view in full size

### DIFF
--- a/app/views/oneline/list.html.erb
+++ b/app/views/oneline/list.html.erb
@@ -62,9 +62,9 @@
           <% if oneline.images.attached? %>
             <div class="uk-grid-medium uk-child-width-expand@s" uk-grid>
             <% oneline.images.each do |image| %>
-            <div class="uk-width-1-2@l uk-width-1-1@m">
+            <a class="uk-width-1-2@l uk-width-1-1@m" uk-toggle="target: #attached-image-modal" data-image-src="<% image_url(url_for(image)) %>">
               <%= image_tag(image_url(url_for(image)), loading: "lazy", class: "uk-card uk-card-default uk-card-body oneline-image-box") %>
-            </div>
+            </a>
               <% end %>
             </div>
           <% end %>
@@ -80,3 +80,25 @@
   <div class="uk-width-1-3@m"><%= paginate @onelines %></div>
   <div class="uk-width-1-3@m uk-width-small@s"></div>
 </div>
+
+<div id="attached-image-modal" uk-modal class="uk-flex-top">
+  <div class="uk-modal-dialog uk-width-auto uk-margin-auto-vertical">
+    <button class="uk-modal-close-outside uk-close-large" type="button" uk-close></button>
+    <img id="attached-image-view" alt="">
+  </div>
+</div>
+
+<script type="text/javascript">
+  var payload = null;
+  UIkit.util.on('#modal-test', 'click', function (e) {
+    e.preventDefault();
+    e.target.blur();
+    payload = e.target.dataset.imageSrc;
+    if (payload != null) {
+      UIkit.modal('#attached-image-modal').show();
+    }
+  });
+  UIkit.util.on('#attached-image-modal', 'show', function () {
+    document.getElementById('attached-image-view').setAttribute('src', payload);
+  });
+</script>


### PR DESCRIPTION
At `oneline`, a full size image is always loaded to the browser while there's no way to open that in full resolution.
This commit will add a modal definition dedicated to view the image in full size.
