### PR TITLE
fix image modal trigger

### DIFF
--- a/app/views/oneline/list.html.erb
+++ b/app/views/oneline/list.html.erb
@@ -62,7 +62,7 @@
           <% if oneline.images.attached? %>
             <div class="uk-grid-medium uk-child-width-expand@s" uk-grid>
             <% oneline.images.each do |image| %>
-            <a class="uk-width-1-2@l uk-width-1-1@m" uk-toggle="target: #attached-image-modal" data-image-src="<% image_url(url_for(image)) %>">
+            <a class="uk-width-1-2@l uk-width-1-1@m attached-image-modal-opener" data-image-src="<% image_url(url_for(image)) %>">
               <%= image_tag(image_url(url_for(image)), loading: "lazy", class: "uk-card uk-card-default uk-card-body oneline-image-box") %>
             </a>
               <% end %>
@@ -90,7 +90,7 @@
 
 <script type="text/javascript">
   var payload = null;
-  UIkit.util.on('#modal-test', 'click', function (e) {
+  UIkit.util.on('.attached-image-modal-opener', 'click', function (e) {
     e.preventDefault();
     e.target.blur();
     payload = e.target.dataset.imageSrc;


### PR DESCRIPTION
This pull request fixes following errors in 70d9f8a5aa4d08fb29fd7d12228c309ab7686a1e

- [x] Anchor in the html does not trigger the onClick method in the js.
- [x] The onClick method was targeting at a already removed element which had been for testing purpose.

